### PR TITLE
Hotfixed OLED init

### DIFF
--- a/Drivers/oled_0_96/oled096.c
+++ b/Drivers/oled_0_96/oled096.c
@@ -2,7 +2,7 @@
  * oled096.c
  *
  *  Created on: Sep 18, 2021
- *      Author: Maxim Hodnenko
+ *      Authors: Maxim Hodnenko, Nulliik
  */
 
 
@@ -152,8 +152,6 @@ OLED_StatusTypeDef OLED_Init(OLED_HandleTypeDef* OLED)
 	if(Result != OLED_OK){
 		  OLED_ErrorHandler(OLED);
 	}
-
-	Result = OLED_Set_Cursor(OLED,0,0);
 
 	return Result;
 }

--- a/Drivers/oled_0_96/oled096.h
+++ b/Drivers/oled_0_96/oled096.h
@@ -7,7 +7,7 @@
   * @attention
   *
   *  Created on: Sep 18, 2021
-  *      Author: Maxim Hodnenko
+  *      Authors: Maxim Hodnenko, Nulliik
   *
   ******************************************************************************
   */

--- a/Drivers/oled_0_96/ssd1306.h
+++ b/Drivers/oled_0_96/ssd1306.h
@@ -2,7 +2,7 @@
  * ssd1306.h
  *
  *  Created on: 5 нояб. 2021 г.
- *      Author: Maximus
+ *      Author: Maxim Hodnenko, Nulliik
  */
 
 #ifndef SSD1306_H_


### PR DESCRIPTION
OLED_Set_Cursor resulted wrong behavior on current realization of OLED_FrameRefresh.
Updated Authors.